### PR TITLE
Messaging/Kestrel: listen on 0.0.0.0 instead of localhost (fixes #68)

### DIFF
--- a/Source/NWheels.Platform.Messaging.Adapters.AspNetKestrel/KestrelHttpEndpoint.cs
+++ b/Source/NWheels.Platform.Messaging.Adapters.AspNetKestrel/KestrelHttpEndpoint.cs
@@ -87,11 +87,11 @@ namespace NWheels.Platform.Messaging.Adapters.AspNetKestrel
         {
             _listenUrls = ImmutableArray<string>
                 .Empty
-                .Add($"http://localhost:{_configuration.Port}");
+                .Add($"http://0.0.0.0:{_configuration.Port}");
 
             if (_configuration.Https != null)
             {
-                _listenUrls = _listenUrls.Add($"https://localhost:{_configuration.Https.Port}");
+                _listenUrls = _listenUrls.Add($"https://0.0.0.0:{_configuration.Https.Port}");
             }
         }
 


### PR DESCRIPTION
This PR handles #68.