### PR TITLE
Switch code coverage to codecov.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,7 @@ https://en.wikipedia.org/wiki/Test-driven_development) (TDD). Testing is an inte
 - **Integration tests**: testing connection between ports and adapters, with real techology stacks attached. 
   - _Example: integration tests of an ORM adapter should run against a real database_.
 - **System tests**: running sample microservice(s), testing them  through their endpoints (API calls or messages).
-  -  _Example: system tests of an in-memory data grid platform should run a sample microservice implemented on top of the in-memory data grid. The microservice should run in real containers, with real communication endpoints and databases. The tests are performed by feeding the microservice with input messages, and validating its output messages through communication endpontss._
+  -  _Example: system tests of an in-memory data grid platform should run a sample microservice implemented on top of the in-memory data grid. The microservice should run in real containers, with real communication endpoints and databases. The tests are performed by feeding the microservice with input messages, and validating its output messages through communication endpoints._
 - **End-to-end (e2e) tests**: running a whole sample application including microservices and UI apps, testing it through UI automation. E2e tests differ from sytstem tests in that the system is tested through user interface. 
   - _Example: UI platform should be tested by running a sample application in a real UI environment (e.g. on a mobile device), with real microservice containers and databases. The tests are performed by automation of UI inputs and validation of UI outputs_. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,10 +197,10 @@ Currently, the following features are missing in VSCode, stopping us from migrat
 
 We use the following online services, provided for free:
 
-- [NuGet.org](https://www.nuget.org/) - package repository
+- [NuGet.org](https://www.nuget.org/) - package repository (planned)
 - [AppVeyor](https://ci.appveyor.com/project/felix-b/nwheels-bk3vs/branch/master) - continuous integration build on Windows
 - [Travis CI](https://travis-ci.org/) (planned) - continuous integration build on Linux
-- [Coveralls](https://coveralls.io/github/felix-b/NWheels?branch=master) - test coverage reports
+- [CodeCov](https://codecov.io/github/felix-b/NWheels) - test coverage reporting
 
 ### Testing
 
@@ -376,7 +376,7 @@ This PR handles #68 - listen on 0.0.0.0 instead of localhost
 
 ### Work in progress
 
-We encourage submitting work-in-progress PRs, so that the community can review and react early. 
+We encourage submitting work-in-progress PRs, so that other contributors can review and react early. 
 
 - Please prefix names of  work-in-progress PRs with "_WIP_" - for example, "_WIP - listen on 0.0.0.0 instead of localhost_". We will know that it's an ongoing effort and give feedback accordingly.
 - Once you consider the PR ready, please remove the "_WIP_" prefix from its name. We will treat it as a candidate for merging. 
@@ -401,7 +401,10 @@ Before a PR can be merged, it must meet the following requirements:
 - The code must be covered by tests. 
   - If the PR includes changes to existing functionality, the tests that cover changed functionality must be changed accordingly.
   - Any appropriate combination of unit/integration/system tests is accepted, and their union coverage is counted. 
-  - Coverage of less than 80% must be justified - comment on the PR thread.
+  - Coverage summary is automatically posted by CodeCov on the PR thread. 
+  - Coverage of 80% is the required minimum (validated by CodeCov).
+  - Coverage of less than 100% must be justified - comment on the PR thread (e.g., a race condition that cannot be reliably reproduced).
+  - PR is not allowed to drop the coverage by more than 5% compared to its base in `master` (validated by CodeCov).  
 - The PR must pass CI builds attached to NWheels repo. Their details appear on the PR issue thread.
 - The PR must have a review with approval by one of project maintainers.
 
@@ -488,9 +491,10 @@ If your environment was set up correctly, the build should be successful.
 
 1. Continuous integration builds will run on every push to the PR branch. The builds are listed under the Checks section in the end of PR thread. Fix build failures, if any occur.     
 
-1. Continue working and pushing more commits. Make sure your changes comply with the [coding conventions](#coding-conventions). Keep CI builds passing. Watch for comments and reviews from other contributors. Be responsive to them.
+1. Continue working and pushing more commits. Make sure your changes comply with the [coding conventions](#coding-conventions). Keep CI builds passing. Keep test coverage above 80%. Watch for comments and reviews from other contributors. Be responsive to them.
    - Reviews will be posted on the PR thread. 
    - Comments can be posted on either PR or the issue thread.
+   - Test coverage summary will be automatically posted by CodeCov on the PR thread. 
 
 1. When you consider the issue to be resolved, rename the pull request and remove the "_WIP_" prefix. Watch for a review from one of project maintainers. Follow up with answers and changes, if any are requested.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,8 +204,12 @@ We use the following online services, provided for free:
 
 ### Testing
 
-C# code must be covered with automatic tests. We practice [test-driven development](
-https://en.wikipedia.org/wiki/Test-driven_development) (TDD). Testing is an integral part of any change made to production code. Coverage of at least 80% is a requirement. Any combination of the following is counted towards the total coverage:
+Automated testing is a vital part of the project. Number of subjects that NWheels covers is large enough to make manual testing impossible. Considering that NWheels is aimed to serve a basis for numerous applications, we cannot afford functionality that is not automatically verifiable by continuous delivery pipeline. 
+
+For this reason, we practice [test-driven development](
+https://en.wikipedia.org/wiki/Test-driven_development) (TDD). Testing is an integral part of any change made to production code. 
+
+In particular, all C# code must be covered with automatic tests. We use code coverage metric to validate that. Any combination of the following is counted towards the total coverage:
 
 - **Unit tests**: testing pieces of logic in isolation from their environment.
   -  _Example: unit-testing of a string formatting utility is isolated from other components, let alone real microservice containers, databases, communication middleware, etc_.
@@ -215,6 +219,8 @@ https://en.wikipedia.org/wiki/Test-driven_development) (TDD). Testing is an inte
   -  _Example: system tests of an in-memory data grid platform should run a sample microservice implemented on top of the in-memory data grid. The microservice should run in real containers, with real communication endpoints and databases. The tests are performed by feeding the microservice with input messages, and validating its output messages through communication endpoints._
 - **End-to-end (e2e) tests**: running a whole sample application including microservices and UI apps, testing it through UI automation. E2e tests differ from sytstem tests in that the system is tested through user interface. 
   - _Example: UI platform should be tested by running a sample application in a real UI environment (e.g. on a mobile device), with real microservice containers and databases. The tests are performed by automation of UI inputs and validation of UI outputs_. 
+
+We attempt to achieve 100% coverage. To account for corner cases that cannot be reliably tested in an automated way, we define the minimum of 80% coverage as the requirement. Automated testing is a vital part of NWheels project. 
 
 Note: additional kinds of tests include stress/load testing, penetration testing, etc. They are not part of the TDD methodology. Development and maintenance of such tests is tracked by separate task issues. 
 
@@ -307,7 +313,7 @@ Single-project convention is preferred when multiple projects separated by test 
   - use least possible visibility for types and members 
 - Beware of performance. Avoid performance killers (e.g. Reflection), especially in performance-sensitive parts of code
   - Performance-sensitive parts are those standing on execution paths counted towards system throughput (e.g. request handling pipeline in a web server).
-- Cover production code with tests. Coverage of at least 80% is reuqired. 
+- Cover production code with tests. Coverage of at least 80% is required. 
 
 ### C# coding style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ In particular, all C# code must be covered with automatic tests. We use code cov
 - **End-to-end (e2e) tests**: running a whole sample application including microservices and UI apps, testing it through UI automation. E2e tests differ from sytstem tests in that the system is tested through user interface. 
   - _Example: UI platform should be tested by running a sample application in a real UI environment (e.g. on a mobile device), with real microservice containers and databases. The tests are performed by automation of UI inputs and validation of UI outputs_. 
 
-We attempt to achieve 100% coverage. To account for corner cases that cannot be reliably tested in an automated way, we define the minimum of 80% coverage as the requirement. Automated testing is a vital part of NWheels project. 
+We attempt to achieve 100% coverage. To account for corner cases that cannot be reliably tested in an automated way, we define the minimum of 80% coverage as the requirement. 
 
 Note: additional kinds of tests include stress/load testing, penetration testing, etc. They are not part of the TDD methodology. Development and maintenance of such tests is tracked by separate task issues. 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Linux|Windows|Coverage
+Linux|Windows|Coverage `master`
 -----|-------|--------
-TBD|[![Build status](https://ci.appveyor.com/api/projects/status/qcm23727dm8dplk5/branch/master?svg=true)](https://ci.appveyor.com/project/felix-b/nwheels-bk3vs/branch/master)|[![codecov](https://codecov.io/gh/felix-b/NWheels/branch/pr-codecov/graph/badge.svg)](https://codecov.io/gh/felix-b/NWheels)
+TBD|[![Build status](https://ci.appveyor.com/api/projects/status/qcm23727dm8dplk5/branch/master?svg=true)](https://ci.appveyor.com/project/felix-b/nwheels-bk3vs/branch/master)|[![codecov](https://codecov.io/gh/felix-b/NWheels/graph/badge.svg)](https://codecov.io/gh/felix-b/NWheels)
 
 Welcome to NWheels
 =======

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Linux|Windows|Coverage
 -----|-------|--------
-TBD|[![Build status](https://ci.appveyor.com/api/projects/status/qcm23727dm8dplk5/branch/master?svg=true)](https://ci.appveyor.com/project/felix-b/nwheels-bk3vs/branch/master)|[![Coverage Status](https://coveralls.io/repos/github/felix-b/NWheels/badge.svg?branch=master)](https://coveralls.io/github/felix-b/NWheels?branch=master)
+TBD|[![Build status](https://ci.appveyor.com/api/projects/status/qcm23727dm8dplk5/branch/master?svg=true)](https://ci.appveyor.com/project/felix-b/nwheels-bk3vs/branch/master)|[![codecov](https://codecov.io/gh/felix-b/NWheels/branch/pr-codecov/graph/badge.svg)](https://codecov.io/gh/felix-b/NWheels)
 
 Welcome to NWheels
 =======

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,10 +65,12 @@ test_script:
 
 after_test:
 - cmd: >-
-
-    choco install opencover.portable
+     
+    nuget install OpenCover -Version 4.6.519 -OutputDirectory c:\projects\NWheels\Tools
     
     choco install codecov
+    
+    cd c:\projects\NWheels\Tools\OpenCover.4.6.519\tools
     
     OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Implementation.UnitTests\NWheels.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests"
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,11 @@ clone_folder: c:\projects\NWheels
   
 install:
   # Get the latest stable version of Node.js or io.js
-  #- ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version
   # install modules
-  #- npm install
+  - npm install
   # install angular CLI
-  #- npm install -g @angular/cli
+  - npm install -g @angular/cli
   
 before_build:
 - cmd: >-
@@ -34,7 +34,7 @@ after_build:
 - cmd: >-
     cd c:\projects\NWheels\Source
 
-#   dotnet publish
+    #dotnet publish
 test_script:
 - cmd: >-
     cd c:\projects\NWheels\Source
@@ -88,19 +88,19 @@ after_test:
     
     codecov -f "c:\projects\NWheels\Tools\MergedResult.xml"
 
-#    cd c:\projects\NWheels\Source\Presentation\Web\AppVeyorPoc
-# 
-#    node --version
-# 
-#    npm --version
-#    
-#    npm install
-#     
-#    ng test --single-run=true
-#    
-#    echo export class Configuration{static appVeyorToken = 'token';} > configuration.ts
-#   
-#    ng e2e
+    cd c:\projects\NWheels\Source\Presentation\Web\AppVeyorPoc
+ 
+    node --version
+ 
+    npm --version
+    
+    npm install
+     
+    ng test --single-run=true
+    
+    echo export class Configuration{static appVeyorToken = 'token';} > configuration.ts
+   
+    ng e2e
     
 ## Pause build until file from desktop will be removed
 #on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,11 @@ clone_folder: c:\projects\NWheels
   
 install:
   # Get the latest stable version of Node.js or io.js
-  - ps: Install-Product node $env:nodejs_version
+  #- ps: Install-Product node $env:nodejs_version
   # install modules
-  - npm install
+  #- npm install
   # install angular CLI
-  - npm install -g @angular/cli
+  #- npm install -g @angular/cli
   
 before_build:
 - cmd: >-
@@ -34,7 +34,7 @@ after_build:
 - cmd: >-
     cd c:\projects\NWheels\Source
 
-    dotnet publish
+    #dotnet publish
 test_script:
 - cmd: >-
     cd c:\projects\NWheels\Source
@@ -86,19 +86,19 @@ after_test:
     
     codecov -f "c:\projects\NWheels\Tools\MergedResult.xml"
 
-    cd c:\projects\NWheels\Source\Presentation\Web\AppVeyorPoc
- 
-    node --version
- 
-    npm --version
-    
-    npm install
-     
-    ng test --single-run=true
-    
-    echo export class Configuration{static appVeyorToken = 'token';} > configuration.ts
-   
-    ng e2e
+#    cd c:\projects\NWheels\Source\Presentation\Web\AppVeyorPoc
+# 
+#    node --version
+# 
+#    npm --version
+#    
+#    npm install
+#     
+#    ng test --single-run=true
+#    
+#    echo export class Configuration{static appVeyorToken = 'token';} > configuration.ts
+#   
+#    ng e2e
     
 ## Pause build until file from desktop will be removed
 #on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,6 +84,8 @@ after_test:
     
     c:\projects\NWheels\Tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Platform.Messaging.Tests\NWheels.Platform.Messaging.Tests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
     
+    cd c:\projects\NWheels
+    
     codecov -f "c:\projects\NWheels\Tools\MergedResult.xml"
 
 #    cd c:\projects\NWheels\Source\Presentation\Web\AppVeyorPoc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,8 +33,7 @@ build:
 after_build:
 - cmd: >-
     cd c:\projects\NWheels\Source
-
-    #dotnet publish
+    
 test_script:
 - cmd: >-
     cd c:\projects\NWheels\Source

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,21 +70,19 @@ after_test:
     
     choco install codecov
     
-    cd c:\projects\NWheels\Tools\OpenCover.4.6.519\tools
-
-    OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Implementation.UnitTests\NWheels.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests"
+    c:\projects\NWheels\Tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Implementation.UnitTests\NWheels.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests"
     
-    OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Injection.Adapters.Autofac.UnitTests\NWheels.Injection.Adapters.Autofac.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
+    c:\projects\NWheels\Tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Injection.Adapters.Autofac.UnitTests\NWheels.Injection.Adapters.Autofac.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
     
-    OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Compilation.Adapters.Roslyn.UnitTests\NWheels.Compilation.Adapters.Roslyn.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
+    c:\projects\NWheels\Tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Compilation.Adapters.Roslyn.UnitTests\NWheels.Compilation.Adapters.Roslyn.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
     
-    OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Platform.Rest.Implementation.UnitTests\NWheels.Platform.Rest.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
+    c:\projects\NWheels\Tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Platform.Rest.Implementation.UnitTests\NWheels.Platform.Rest.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
     
-    OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Frameworks.Ddd.Implementation.UnitTests\NWheels.Frameworks.Ddd.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
+    c:\projects\NWheels\Tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Frameworks.Ddd.Implementation.UnitTests\NWheels.Frameworks.Ddd.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
     
-    OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.SystemTests\NWheels.SystemTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
+    c:\projects\NWheels\Tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.SystemTests\NWheels.SystemTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
     
-    OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Platform.Messaging.Tests\NWheels.Platform.Messaging.Tests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
+    c:\projects\NWheels\Tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Platform.Messaging.Tests\NWheels.Platform.Messaging.Tests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
     
     codecov -f "c:\projects\NWheels\Tools\MergedResult.xml"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ after_build:
 - cmd: >-
     cd c:\projects\NWheels\Source
 
-    #dotnet publish
+#   dotnet publish
 test_script:
 - cmd: >-
     cd c:\projects\NWheels\Source

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,13 +65,13 @@ test_script:
 
 after_test:
 - cmd: >-
-     
+    
     nuget install OpenCover -Version 4.6.519 -OutputDirectory c:\projects\NWheels\Tools
     
     choco install codecov
     
     cd c:\projects\NWheels\Tools\OpenCover.4.6.519\tools
-    
+
     OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Implementation.UnitTests\NWheels.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests"
     
     OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Injection.Adapters.Autofac.UnitTests\NWheels.Injection.Adapters.Autofac.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,6 @@ image: Visual Studio 2017
 environment:
   nodejs_version: "LTS"
   
-  COVERALLS_REPO_TOKEN:
-    secure: WSnzdH1x3Yyt3a+i3UlByl1p+YJ/M6dmzLJxZAB66s92CrNyOKJkaNu47Ljqct2i
-  
 clone_folder: c:\projects\NWheels
   
 install:
@@ -68,9 +65,10 @@ test_script:
 
 after_test:
 - cmd: >-
-    nuget install OpenCover -Version 4.6.519 -OutputDirectory c:\projects\NWheels\Tools
+
+    choco install opencover.portable
     
-    cd c:\projects\NWheels\Tools\OpenCover.4.6.519\tools
+    choco install codecov
     
     OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Implementation.UnitTests\NWheels.Implementation.UnitTests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests"
     
@@ -86,11 +84,7 @@ after_test:
     
     OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test c:\projects\NWheels\Source\NWheels.Platform.Messaging.Tests\NWheels.Platform.Messaging.Tests.csproj" -register:user -output:c:\projects\NWheels\Tools\MergedResult.xml -oldStyle -filter:"+[*]* -[*FluentAssertions*]* -[*]*UnitTests" -mergeoutput
     
-    nuget install coveralls.net -Version 0.412.0 -OutputDirectory c:\projects\NWheels\Tools
-    
-    cd c:\projects\NWheels\Tools\coveralls.net.0.412\tools
-    
-    csmacnz.Coveralls.exe --opencover -i c:\projects\NWheels\Tools\MergedResult.xml
+    codecov -f "c:\projects\NWheels\Tools\MergedResult.xml"
 
     cd c:\projects\NWheels\Source\Presentation\Web\AppVeyorPoc
  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  precision: 1
+  round: down
+  range: "70...90"
+  status:
+    project:
+      default:
+        target: 50
+        threshold: 5
+
+ignore:
+  Source/*.*Tests


### PR DESCRIPTION
This PR handles #72 - create convenient view of code coverage results.

The actual coverage profiling is done by OpenCover as before, but the results will be handled by codecov.io.